### PR TITLE
Add proposal for Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ npm install @pulumi/pulumi
 
 For a list of repository templates that show you how to use Pulumi for deploying your Twilio projects, see the [Examples repo](https://github.com/twilio-infra-as-code/examples).
 
+# Documentation 
+
+## Products coverage 
+
+Below the list of Twilio products and their readiness
+
+| Product | Implementation | Test | Samples |
+|---|---|---|---|
+|Taskrouter| :white_check_mark: | Manual :white_check_mark: | [Taskrouter Contact Center](https://github.com/twilio-infra-as-code/taskrouter-contact-center)|
+|Serverless| :white_check_mark: | :construction: |  |
+|Studio| :white_check_mark: | :construction: |  |
+
+
+
+## Paths 
+
+### Taskrouter 
+
+| Path | Description |
+|---|----|
+|`['taskroter', 'workspaces']`| Taskrouter Workspace |
+| `['taskrouter', { workspaces: <workspace SID> }, 'taskQueues']`| Taskrouter task queue |
+| `['taskrouter', { workspaces: <workspace SID> }, 'workers']`| Taskrouter worker |
+| `['taskrouter', { workspaces: <workspace SID> }, 'workflows']`| Taskrouter workflow |
+
+### Studio 
+
+| Path | Description |
+|---|----|
+| |  |
 
 ## More about the project
 


### PR DESCRIPTION
First proposal for a better documentation of the Pulumi provider implementation. The code samples are really good, but I feel we need to provide a better documentation and (most importantly) a test coverage of what works and what have not been tested to avoid developer frustrations. 

My proposal is to divide the documentation section in two: 
* Product coverage: here we document which Twilio product can be used with the Pulumi provider and which one we already tested. My proposal is also to provide simple examples that illustrated fully one product only
* Paths documentation: one of the feed-back we received on the first blogpost was that it's not clear how the API paths map into the resources descriptor array. We provided an example in the blogpost but that's limited to Taskrouter. We need to provide those paths for all the product we are confident we support 

@kaiquelupo @bermudezmt let me know what you think of this proposal. 