### PR TITLE
Fix for `Unexpected struct type`

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -104,7 +104,7 @@ class ResourceProvider implements pulumi.dynamic.ResourceProvider {
             
         return {
             id: info.sid,
-            outs: { sid: info.sid, inputs: cleanObject(inputs, false), info },
+            outs: { sid: info.sid, inputs: cleanObject(inputs, false), info: cleanObject(info, false) },
         };
     }
 
@@ -117,7 +117,7 @@ class ResourceProvider implements pulumi.dynamic.ResourceProvider {
         const info = cleanObject(await getAPI(client, resource)(id).update(attributes), false);
 
         return {
-            outs: { sid: info.sid, inputs: cleanObject(news, false), info }
+            outs: { sid: info.sid, inputs: cleanObject(news, false), info: cleanObject(info, false) }
         }   
      }
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -34,9 +34,11 @@ export const cleanObject = (obj: any, isServerless: boolean) => {
             if(cur.match(/^_/)){
                 return pr;
             }
+            // Fix: Pulumi doesn't like objects containing items with 
+            // undefined value. Setting those to `null`
             return {
                 ...pr,
-                [cur]: obj[cur]
+                [cur]: obj[cur] === undefined ? null : obj[cur]
             }
         }, {})
 


### PR DESCRIPTION
In some circustmances, Twilio client return an object with some key(s) whose value is `undefined`. This somehow breaks Pulumi SDk.

Replace `undefined` with `null` for those object items.

Fix #6